### PR TITLE
Linux 4.14.18 patch release 05-17-22

### DIFF
--- a/dsc-linux-4.14.18/patches-2022-05/00_emmc_hwreset.patch
+++ b/dsc-linux-4.14.18/patches-2022-05/00_emmc_hwreset.patch
@@ -1,0 +1,1299 @@
+From 7751ae96a468bb4b4c90c633a11e3b61b0acf29e Mon Sep 17 00:00:00 2001
+From: Brad Larson <brad@pensando.io>
+Date: Tue, 17 May 2022 13:37:25 -0700
+Subject: [PATCH] mfd: pensando_elbasr: Add Pensando Elba System Resource Chip
+
+Add support for Pensando Elba System Resource Chip
+for userspace access to the device and hardware
+reset of the eMMC.  The System Resource Chip is
+accessed over a SPI bus using regmap framework.
+
+Signed-off-by: Brad Larson <brad@pensando.io>
+---
+ .../boot/dts/pensando/elba-asic-common.dtsi   |  29 +-
+ arch/arm64/configs/elba_defconfig             |   3 +
+ drivers/mfd/Kconfig                           |  11 +
+ drivers/mfd/Makefile                          |   1 +
+ drivers/mfd/pensando-elbasr.c                 | 894 ++++++++++++++++++
+ drivers/mmc/host/sdhci-cadence.c              |  28 +
+ drivers/mmc/host/sdhci-cadence.h              |   1 +
+ drivers/reset/Kconfig                         |   8 +
+ drivers/reset/Makefile                        |   1 +
+ drivers/reset/reset-elbasr.c                  |  84 ++
+ drivers/spi/spidev.c                          |   1 -
+ include/linux/mfd/pensando-elbasr.h           |  43 +
+ 12 files changed, 1094 insertions(+), 10 deletions(-)
+ create mode 100644 drivers/mfd/pensando-elbasr.c
+ create mode 100644 drivers/reset/reset-elbasr.c
+ create mode 100644 include/linux/mfd/pensando-elbasr.h
+
+diff --git a/arch/arm64/boot/dts/pensando/elba-asic-common.dtsi b/arch/arm64/boot/dts/pensando/elba-asic-common.dtsi
+index 16d37108fb0a..8a341927be88 100644
+--- a/arch/arm64/boot/dts/pensando/elba-asic-common.dtsi
++++ b/arch/arm64/boot/dts/pensando/elba-asic-common.dtsi
+@@ -49,6 +49,9 @@
+ 
+ &emmc {
+ 	bus-width = <8>;
++	cap-mmc-hw-reset;
++	reset-names = "hw";
++	resets = <&rstc 0>;
+ 	status = "ok";
+ };
+ 
+@@ -81,33 +84,41 @@
+ 	num-cs = <4>;
+ 	cs-gpios = <&spics 0 0>, <&spics 1 0>, <&porta 1 0>, <&porta 7 0>;
+ 	status = "okay";
+-	cpld@0 {
+-		compatible = "pensando,cpld";
++	spi@0 {
++		compatible = "pensando,elbasr";
+ 		#address-cells = <1>;
+-		#size-cells = <1>;
++		#size-cells = <0>;
+ 		spi-max-frequency = <12000000>;
+ 		reg = <0>;
++
++		rstc: reset-controller@0 {
++			compatible = "pensando,elbasr-reset";
++			reg = <0>;	/* CS0 */
++			#address-cells = <1>;
++			#size-cells = <0>;
++			#reset-cells = <1>;
++		};
+ 	};
+-	cpld@1 {
++	spi@1 {
+ 		compatible = "pensando,cpld";
+ 		#address-cells = <1>;
+-		#size-cells = <1>;
++		#size-cells = <0>;
+ 		spi-max-frequency = <12000000>;
+ 		reg = <1>;
+ 	};
+-	cpld@2 {
++	spi@2 {
+ 		compatible = "pensando,cpld-rd1173";
+ 		#address-cells = <1>;
+-		#size-cells = <1>;
++		#size-cells = <0>;
+ 		spi-max-frequency = <12000000>;
+ 		reg = <2>;
+ 		interrupt-parent = <&porta>;
+ 		interrupts = <0 IRQ_TYPE_LEVEL_LOW>;
+ 	};
+-	cpld@3 {
++	spi@3 {
+ 		compatible = "pensando,cpld";
+ 		#address-cells = <1>;
+-		#size-cells = <1>;
++		#size-cells = <0>;
+ 		spi-max-frequency = <12000000>;
+ 		reg = <3>;
+ 	};
+diff --git a/arch/arm64/configs/elba_defconfig b/arch/arm64/configs/elba_defconfig
+index 6aa5ea405e8d..750c3ce7564c 100644
+--- a/arch/arm64/configs/elba_defconfig
++++ b/arch/arm64/configs/elba_defconfig
+@@ -201,6 +201,7 @@ CONFIG_THERMAL=y
+ CONFIG_WATCHDOG=y
+ CONFIG_SOFT_WATCHDOG=y
+ CONFIG_DW_WATCHDOG=y
++CONFIG_MFD_PENSANDO_ELBASR=y
+ CONFIG_MFD_SYSCON=y
+ # CONFIG_RC_CORE is not set
+ # CONFIG_VGA_ARB is not set
+@@ -229,6 +230,8 @@ CONFIG_CLK_QORIQ=y
+ # CONFIG_IOMMU_SUPPORT is not set
+ CONFIG_PENSANDO_SOC_BSM_ENABLE=y
+ CONFIG_EXTCON=y
++CONFIG_RESET_CONTROLLER=y
++CONFIG_RESET_ELBASR=y
+ CONFIG_GENERIC_PHY=y
+ CONFIG_RAS=y
+ CONFIG_EXT3_FS=y
+diff --git a/drivers/mfd/Kconfig b/drivers/mfd/Kconfig
+index fc5e4fef89d2..b5100402544c 100644
+--- a/drivers/mfd/Kconfig
++++ b/drivers/mfd/Kconfig
+@@ -837,6 +837,17 @@ config MFD_PCF50633
+ 	  facilities, and registers devices for the various functions
+ 	  so that function-specific drivers can bind to them.
+ 
++config MFD_PENSANDO_ELBASR
++	bool "Pensando Elba System Resource chip"
++	depends on ARCH_PENSANDO_ELBA_SOC && SPI_MASTER=y && OF
++	select REGMAP_SPI
++	select MFD_CORE
++	help
++	  Support for the Pensando Elba SoC System Resource chip using
++	  the SPI interface.  This driver provides common support for
++	  accessing the device functions to include userspace access
++	  and eMMC hardware reset control.
++
+ config PCF50633_ADC
+ 	tristate "NXP PCF50633 ADC"
+ 	depends on MFD_PCF50633
+diff --git a/drivers/mfd/Makefile b/drivers/mfd/Makefile
+index 8703ff17998e..c59a12bdebd5 100644
+--- a/drivers/mfd/Makefile
++++ b/drivers/mfd/Makefile
+@@ -222,6 +222,7 @@ obj-$(CONFIG_INTEL_SOC_PMIC_CHTWC)	+= intel_soc_pmic_chtwc.o
+ obj-$(CONFIG_MFD_MT6397)	+= mt6397-core.o
+ 
+ obj-$(CONFIG_MFD_ALTERA_A10SR)	+= altera-a10sr.o
++obj-$(CONFIG_MFD_PENSANDO_ELBASR)	+= pensando-elbasr.o
+ obj-$(CONFIG_MFD_SUN4I_GPADC)	+= sun4i-gpadc.o
+ 
+ obj-$(CONFIG_MFD_STM32_LPTIMER)	+= stm32-lptimer.o
+diff --git a/drivers/mfd/pensando-elbasr.c b/drivers/mfd/pensando-elbasr.c
+new file mode 100644
+index 000000000000..c0170801892a
+--- /dev/null
++++ b/drivers/mfd/pensando-elbasr.c
+@@ -0,0 +1,894 @@
++/*
++ * Pensando Elba System Resource MFD Driver
++ *
++ * Copyright (C) 2022 Pensando Systems, Inc.
++ * Copyright (C) 2006 SWAPP
++ *      Andrea Paterniani <a.paterniani@swapp-eng.it>
++ * Copyright (C) 2007 David Brownell (simplification, cleanup)
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * SPI access for Pensando Elba System Resource Chip for
++ * userspace access and emmc hardware reset with a subdevice.
++ *
++ * Adapted from spidev.c
++ */
++
++#include <linux/mfd/pensando-elbasr.h>
++#include <linux/mfd/core.h>
++#include <linux/module.h>
++#include <linux/ioctl.h>
++#include <linux/fs.h>
++#include <linux/device.h>
++#include <linux/err.h>
++#include <linux/list.h>
++#include <linux/errno.h>
++#include <linux/mutex.h>
++#include <linux/slab.h>
++#include <linux/compat.h>
++#include <linux/of.h>
++#include <linux/of_device.h>
++#include <linux/acpi.h>
++
++#include <linux/spi/spi.h>
++#include <linux/spi/spidev.h>
++
++#include <linux/uaccess.h>
++
++#define ELBASR_SPI_CMD_REGRD	0x0b
++#define ELBASR_SPI_CMD_REGWR	0x02
++
++static const struct mfd_cell pensando_elbasr_subdev_info[] = {
++	{
++		.name = "pensando_elbasr_reset",
++		.of_compatible = "pensando,elbasr-reset",
++	},
++};
++
++/*
++ * This supports access to SPI devices using normal userspace I/O calls.
++ * Note that while traditional UNIX/POSIX I/O semantics are half duplex,
++ * and often mask message boundaries, full SPI support requires full duplex
++ * transfers.  There are several kinds of internal message boundaries to
++ * handle chipselect management and other protocol options.
++ *
++ * SPI has a character major number assigned.  We allocate minor numbers
++ * dynamically using a bitmask.  You must use hotplug tools, such as udev
++ * (or mdev with busybox) to create and destroy the /dev/spidevB.C device
++ * nodes, since there is no fixed association of minor numbers with any
++ * particular SPI bus or device.
++ */
++#define SPIDEV_MAJOR			153	/* assigned */
++#define N_SPI_MINORS			32	/* ... up to 256 */
++
++static DECLARE_BITMAP(minors, N_SPI_MINORS);
++
++/* Bit masks for spi_device.mode management.  Note that incorrect
++ * settings for some settings can cause *lots* of trouble for other
++ * devices on a shared bus:
++ *
++ *  - CS_HIGH ... this device will be active when it shouldn't be
++ *  - 3WIRE ... when active, it won't behave as it should
++ *  - NO_CS ... there will be no explicit message boundaries; this
++ *	is completely incompatible with the shared bus model
++ *  - READY ... transfers may proceed when they shouldn't.
++ *
++ * REVISIT should changing those flags be privileged?
++ */
++#define SPI_MODE_MASK           (SPI_CPHA | SPI_CPOL | SPI_CS_HIGH \
++				| SPI_LSB_FIRST | SPI_3WIRE | SPI_LOOP \
++				| SPI_NO_CS | SPI_READY | SPI_TX_DUAL \
++				| SPI_TX_QUAD | SPI_RX_DUAL | SPI_RX_QUAD)
++
++static LIST_HEAD(device_list);
++static DEFINE_MUTEX(device_list_lock);
++
++static unsigned int bufsiz = 4096;
++module_param(bufsiz, uint, S_IRUGO);
++MODULE_PARM_DESC(bufsiz, "data bytes in biggest supported SPI message");
++
++static ssize_t
++elbasr_spi_sync(struct elbasr_data *elbasr_spi, struct spi_message *message)
++{
++	int status;
++	struct spi_device *spi;
++
++	spin_lock_irq(&elbasr_spi->spi_lock);
++	spi = elbasr_spi->spi;
++	spin_unlock_irq(&elbasr_spi->spi_lock);
++
++	if (spi == NULL)
++		status = -ESHUTDOWN;
++	else
++		status = spi_sync(spi, message);
++
++	if (status == 0)
++		status = message->actual_length;
++
++	return status;
++}
++
++static inline ssize_t
++elbasr_spi_sync_write(struct elbasr_data *elbasr, size_t len)
++{
++	struct spi_transfer	t = {
++			.tx_buf		= elbasr->tx_buffer,
++			.len		= len,
++			.speed_hz	= elbasr->speed_hz,
++		};
++	struct spi_message	m;
++
++	spi_message_init(&m);
++	spi_message_add_tail(&t, &m);
++	return elbasr_spi_sync(elbasr, &m);
++}
++
++static inline ssize_t
++elbasr_spi_sync_read(struct elbasr_data *elbasr, size_t len)
++{
++	struct spi_transfer	t = {
++			.rx_buf		= elbasr->rx_buffer,
++			.len		= len,
++			.speed_hz	= elbasr->speed_hz,
++		};
++	struct spi_message	m;
++
++	spi_message_init(&m);
++	spi_message_add_tail(&t, &m);
++	return elbasr_spi_sync(elbasr, &m);
++}
++
++/* Read-only message with current device setup */
++static ssize_t
++elbasr_spi_read(struct file *filp, char __user *buf, size_t count, loff_t *f_pos)
++{
++	struct elbasr_data *elbasr;
++	ssize_t status = 0;
++
++	/* chipselect only toggles at start or end of operation */
++	if (count > bufsiz)
++		return -EMSGSIZE;
++
++	elbasr = filp->private_data;
++
++	mutex_lock(&elbasr->buf_lock);
++	status = elbasr_spi_sync_read(elbasr, count);
++	if (status > 0) {
++		unsigned long missing;
++
++		missing = copy_to_user(buf, elbasr->rx_buffer, status);
++		if (missing == status)
++			status = -EFAULT;
++		else
++			status = status - missing;
++	}
++	mutex_unlock(&elbasr->buf_lock);
++
++	return status;
++}
++
++/* Write-only message with current device setup */
++static ssize_t
++elbasr_spi_write(struct file *filp, const char __user *buf,
++		 size_t count, loff_t *f_pos)
++{
++	struct elbasr_data *elbasr;
++	ssize_t status = 0;
++	unsigned long missing;
++
++	/* chipselect only toggles at start or end of operation */
++	if (count > bufsiz)
++		return -EMSGSIZE;
++
++	elbasr = filp->private_data;
++
++	mutex_lock(&elbasr->buf_lock);
++	missing = copy_from_user(elbasr->tx_buffer, buf, count);
++	if (missing == 0)
++		status = elbasr_spi_sync_write(elbasr, count);
++	else
++		status = -EFAULT;
++	mutex_unlock(&elbasr->buf_lock);
++
++	return status;
++}
++
++static int elbasr_spi_message(struct elbasr_data *elbasr,
++			      struct spi_ioc_transfer *u_xfers,
++			      unsigned int n_xfers)
++{
++	struct spi_message msg;
++	struct spi_transfer *k_xfers;
++	struct spi_transfer *k_tmp;
++	struct spi_ioc_transfer *u_tmp;
++	unsigned int n, total, tx_total, rx_total;
++	u8 *tx_buf, *rx_buf;
++	int status = -EFAULT;
++
++	spi_message_init(&msg);
++	k_xfers = kcalloc(n_xfers, sizeof(*k_tmp), GFP_KERNEL);
++	if (k_xfers == NULL)
++		return -ENOMEM;
++
++	/* Construct spi_message, copying any tx data to bounce buffer.
++	 * We walk the array of user-provided transfers, using each one
++	 * to initialize a kernel version of the same transfer.
++	 */
++	tx_buf = elbasr->tx_buffer;
++	rx_buf = elbasr->rx_buffer;
++	total = 0;
++	tx_total = 0;
++	rx_total = 0;
++	for (n = n_xfers, k_tmp = k_xfers, u_tmp = u_xfers;
++			n;
++			n--, k_tmp++, u_tmp++) {
++		k_tmp->len = u_tmp->len;
++
++		total += k_tmp->len;
++		/* Since the function returns the total length of transfers
++		 * on success, restrict the total to positive int values to
++		 * avoid the return value looking like an error.  Also check
++		 * each transfer length to avoid arithmetic overflow.
++		 */
++		if (total > INT_MAX || k_tmp->len > INT_MAX) {
++			status = -EMSGSIZE;
++			goto done;
++		}
++
++		if (u_tmp->rx_buf) {
++			/* this transfer needs space in RX bounce buffer */
++			rx_total += k_tmp->len;
++			if (rx_total > bufsiz) {
++				status = -EMSGSIZE;
++				goto done;
++			}
++			k_tmp->rx_buf = rx_buf;
++			rx_buf += k_tmp->len;
++		}
++		if (u_tmp->tx_buf) {
++			/* this transfer needs space in TX bounce buffer */
++			tx_total += k_tmp->len;
++			if (tx_total > bufsiz) {
++				status = -EMSGSIZE;
++				goto done;
++			}
++			k_tmp->tx_buf = tx_buf;
++			if (copy_from_user(tx_buf, (const u8 __user *)
++						(uintptr_t) u_tmp->tx_buf,
++					u_tmp->len))
++				goto done;
++			tx_buf += k_tmp->len;
++		}
++
++		k_tmp->cs_change = !!u_tmp->cs_change;
++		k_tmp->tx_nbits = u_tmp->tx_nbits;
++		k_tmp->rx_nbits = u_tmp->rx_nbits;
++		k_tmp->bits_per_word = u_tmp->bits_per_word;
++		k_tmp->delay_usecs = u_tmp->delay_usecs;
++		k_tmp->speed_hz = u_tmp->speed_hz;
++		if (!k_tmp->speed_hz)
++			k_tmp->speed_hz = elbasr->speed_hz;
++
++#ifdef VERBOSE
++		dev_dbg(&elbasr->spi->dev,
++			"  xfer len %u %s%s%s%dbits %u usec %uHz\n",
++			u_tmp->len,
++			u_tmp->rx_buf ? "rx " : "",
++			u_tmp->tx_buf ? "tx " : "",
++			u_tmp->cs_change ? "cs " : "",
++			u_tmp->bits_per_word ? : elbasr->spi->bits_per_word,
++			u_tmp->delay_usecs,
++			u_tmp->speed_hz ? : elbasr->spi->max_speed_hz);
++#endif
++		spi_message_add_tail(k_tmp, &msg);
++	}
++
++	status = elbasr_spi_sync(elbasr, &msg);
++	if (status < 0)
++		goto done;
++
++	/* copy any rx data out of bounce buffer */
++	rx_buf = elbasr->rx_buffer;
++	for (n = n_xfers, u_tmp = u_xfers; n; n--, u_tmp++) {
++		if (u_tmp->rx_buf) {
++			if (copy_to_user((u8 __user *)
++					(uintptr_t) u_tmp->rx_buf, rx_buf,
++					u_tmp->len)) {
++				status = -EFAULT;
++				goto done;
++			}
++			rx_buf += u_tmp->len;
++		}
++	}
++	status = total;
++
++done:
++	kfree(k_xfers);
++	return status;
++}
++
++static struct spi_ioc_transfer *
++elbasr_spi_get_ioc_message(unsigned int cmd,
++			   struct spi_ioc_transfer __user *u_ioc,
++			   unsigned int *n_ioc)
++{
++	u32 tmp;
++
++	/* Check type, command number and direction */
++	if (_IOC_TYPE(cmd) != SPI_IOC_MAGIC
++			|| _IOC_NR(cmd) != _IOC_NR(SPI_IOC_MESSAGE(0))
++			|| _IOC_DIR(cmd) != _IOC_WRITE)
++		return ERR_PTR(-ENOTTY);
++
++	tmp = _IOC_SIZE(cmd);
++	if ((tmp % sizeof(struct spi_ioc_transfer)) != 0)
++		return ERR_PTR(-EINVAL);
++	*n_ioc = tmp / sizeof(struct spi_ioc_transfer);
++	if (*n_ioc == 0)
++		return NULL;
++
++	/* copy into scratch area */
++	return memdup_user(u_ioc, tmp);
++}
++
++static long
++elbasr_spi_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
++{
++	int retval = 0;
++	struct elbasr_data *elbasr;
++	struct spi_device *spi;
++	u32 tmp;
++	unsigned int n_ioc;
++	struct spi_ioc_transfer	*ioc;
++
++	/* Check type and command number */
++	if (_IOC_TYPE(cmd) != SPI_IOC_MAGIC)
++		return -ENOTTY;
++
++	/* guard against device removal before, or while,
++	 * we issue this ioctl.
++	 */
++	elbasr = filp->private_data;
++	spin_lock_irq(&elbasr->spi_lock);
++	spi = spi_dev_get(elbasr->spi);
++	spin_unlock_irq(&elbasr->spi_lock);
++
++	if (spi == NULL)
++		return -ESHUTDOWN;
++
++	/* use the buffer lock here for triple duty:
++	 *  - prevent I/O (from us) so calling spi_setup() is safe;
++	 *  - prevent concurrent SPI_IOC_WR_* from morphing
++	 *    data fields while SPI_IOC_RD_* reads them;
++	 *  - SPI_IOC_MESSAGE needs the buffer locked "normally".
++	 */
++	mutex_lock(&elbasr->buf_lock);
++
++	switch (cmd) {
++	/* read requests */
++	case SPI_IOC_RD_MODE:
++		retval = put_user(spi->mode & SPI_MODE_MASK,
++					(__u8 __user *)arg);
++		break;
++	case SPI_IOC_RD_MODE32:
++		retval = put_user(spi->mode & SPI_MODE_MASK,
++					(__u32 __user *)arg);
++		break;
++	case SPI_IOC_RD_LSB_FIRST:
++		retval = put_user((spi->mode & SPI_LSB_FIRST) ?  1 : 0,
++					(__u8 __user *)arg);
++		break;
++	case SPI_IOC_RD_BITS_PER_WORD:
++		retval = put_user(spi->bits_per_word, (__u8 __user *)arg);
++		break;
++	case SPI_IOC_RD_MAX_SPEED_HZ:
++		retval = put_user(elbasr->speed_hz, (__u32 __user *)arg);
++		break;
++
++	/* write requests */
++	case SPI_IOC_WR_MODE:
++	case SPI_IOC_WR_MODE32:
++		if (cmd == SPI_IOC_WR_MODE)
++			retval = get_user(tmp, (u8 __user *)arg);
++		else
++			retval = get_user(tmp, (u32 __user *)arg);
++		if (retval == 0) {
++			u32	save = spi->mode;
++
++			if (tmp & ~SPI_MODE_MASK) {
++				retval = -EINVAL;
++				break;
++			}
++
++			tmp |= spi->mode & ~SPI_MODE_MASK;
++			spi->mode = (u16)tmp;
++			retval = spi_setup(spi);
++			if (retval < 0)
++				spi->mode = save;
++			else
++				dev_dbg(&spi->dev, "spi mode %x\n", tmp);
++		}
++		break;
++	case SPI_IOC_WR_LSB_FIRST:
++		retval = get_user(tmp, (__u8 __user *)arg);
++		if (retval == 0) {
++			u32	save = spi->mode;
++
++			if (tmp)
++				spi->mode |= SPI_LSB_FIRST;
++			else
++				spi->mode &= ~SPI_LSB_FIRST;
++			retval = spi_setup(spi);
++			if (retval < 0)
++				spi->mode = save;
++			else
++				dev_dbg(&spi->dev, "%csb first\n",
++						tmp ? 'l' : 'm');
++		}
++		break;
++	case SPI_IOC_WR_BITS_PER_WORD:
++		retval = get_user(tmp, (__u8 __user *)arg);
++		if (retval == 0) {
++			u8	save = spi->bits_per_word;
++
++			spi->bits_per_word = tmp;
++			retval = spi_setup(spi);
++			if (retval < 0)
++				spi->bits_per_word = save;
++			else
++				dev_dbg(&spi->dev, "%d bits per word\n", tmp);
++		}
++		break;
++	case SPI_IOC_WR_MAX_SPEED_HZ:
++		retval = get_user(tmp, (__u32 __user *)arg);
++		if (retval == 0) {
++			u32	save = spi->max_speed_hz;
++
++			spi->max_speed_hz = tmp;
++			retval = spi_setup(spi);
++			if (retval == 0)
++				elbasr->speed_hz = tmp;
++			else
++				dev_dbg(&spi->dev, "%d Hz (max)\n", tmp);
++			spi->max_speed_hz = save;
++		}
++		break;
++
++	default:
++		/* segmented and/or full-duplex I/O request */
++		/* Check message and copy into scratch area */
++		ioc = elbasr_spi_get_ioc_message(cmd,
++				(struct spi_ioc_transfer __user *)arg, &n_ioc);
++		if (IS_ERR(ioc)) {
++			retval = PTR_ERR(ioc);
++			break;
++		}
++		if (!ioc)
++			break;	/* n_ioc is also 0 */
++
++		/* translate to spi_message, execute */
++		retval = elbasr_spi_message(elbasr, ioc, n_ioc);
++		kfree(ioc);
++		break;
++	}
++
++	mutex_unlock(&elbasr->buf_lock);
++	spi_dev_put(spi);
++	return retval;
++}
++
++#ifdef CONFIG_COMPAT
++static long
++elbasr_spi_compat_ioc_message(struct file *filp, unsigned int cmd,
++			      unsigned long arg)
++{
++	struct spi_ioc_transfer __user *u_ioc;
++	int retval = 0;
++	struct elbasr_data *elbasr;
++	struct spi_device *spi;
++	unsigned int n_ioc, n;
++	struct spi_ioc_transfer *ioc;
++
++	u_ioc = (struct spi_ioc_transfer __user *) compat_ptr(arg);
++
++	/* guard against device removal before, or while,
++	 * we issue this ioctl.
++	 */
++	elbasr = filp->private_data;
++	spin_lock_irq(&elbasr->spi_lock);
++	spi = spi_dev_get(elbasr->spi);
++	spin_unlock_irq(&elbasr->spi_lock);
++
++	if (spi == NULL)
++		return -ESHUTDOWN;
++
++	/* SPI_IOC_MESSAGE needs the buffer locked "normally" */
++	mutex_lock(&elbasr->buf_lock);
++
++	/* Check message and copy into scratch area */
++	ioc = elbasr_spi_get_ioc_message(cmd, u_ioc, &n_ioc);
++	if (IS_ERR(ioc)) {
++		retval = PTR_ERR(ioc);
++		goto done;
++	}
++	if (!ioc)
++		goto done;	/* n_ioc is also 0 */
++
++	/* Convert buffer pointers */
++	for (n = 0; n < n_ioc; n++) {
++		ioc[n].rx_buf = (uintptr_t) compat_ptr(ioc[n].rx_buf);
++		ioc[n].tx_buf = (uintptr_t) compat_ptr(ioc[n].tx_buf);
++	}
++
++	/* translate to spi_message, execute */
++	retval = elbasr_spi_message(elbasr, ioc, n_ioc);
++	kfree(ioc);
++
++done:
++	mutex_unlock(&elbasr->buf_lock);
++	spi_dev_put(spi);
++	return retval;
++}
++
++static long
++elbasr_spi_compat_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
++{
++	if (_IOC_TYPE(cmd) == SPI_IOC_MAGIC
++			&& _IOC_NR(cmd) == _IOC_NR(SPI_IOC_MESSAGE(0))
++			&& _IOC_DIR(cmd) == _IOC_WRITE)
++		return elbasr_spi_compat_ioc_message(filp, cmd, arg);
++
++	return elbasr_spi_ioctl(filp, cmd, (unsigned long)compat_ptr(arg));
++}
++#else
++#define elbasr_spi_compat_ioctl NULL
++#endif /* CONFIG_COMPAT */
++
++static int elbasr_spi_open(struct inode *inode, struct file *filp)
++{
++	struct elbasr_data *elbasr;
++	int status = -ENXIO;
++
++	mutex_lock(&device_list_lock);
++
++	list_for_each_entry(elbasr, &device_list, device_entry) {
++		if (elbasr->devt == inode->i_rdev) {
++			status = 0;
++			break;
++		}
++	}
++
++	if (status) {
++		pr_debug("elbasr_spi: nothing for minor %d\n", iminor(inode));
++		goto err_find_dev;
++	}
++
++	if (!elbasr->tx_buffer) {
++		elbasr->tx_buffer = kmalloc(bufsiz, GFP_KERNEL);
++		if (!elbasr->tx_buffer) {
++			status = -ENOMEM;
++			goto err_find_dev;
++		}
++	}
++
++	if (!elbasr->rx_buffer) {
++		elbasr->rx_buffer = kmalloc(bufsiz, GFP_KERNEL);
++		if (!elbasr->rx_buffer) {
++			status = -ENOMEM;
++			goto err_alloc_rx_buf;
++		}
++	}
++
++	elbasr->users++;
++	filp->private_data = elbasr;
++	nonseekable_open(inode, filp);
++
++	mutex_unlock(&device_list_lock);
++	return 0;
++
++err_alloc_rx_buf:
++	kfree(elbasr->tx_buffer);
++	elbasr->tx_buffer = NULL;
++err_find_dev:
++	mutex_unlock(&device_list_lock);
++	return status;
++}
++
++static int elbasr_spi_release(struct inode *inode, struct file *filp)
++{
++	struct elbasr_data *elbasr;
++
++	mutex_lock(&device_list_lock);
++	elbasr = filp->private_data;
++	filp->private_data = NULL;
++
++	/* last close? */
++	elbasr->users--;
++	if (!elbasr->users) {
++		int             dofree;
++
++		kfree(elbasr->tx_buffer);
++		elbasr->tx_buffer = NULL;
++
++		kfree(elbasr->rx_buffer);
++		elbasr->rx_buffer = NULL;
++
++		spin_lock_irq(&elbasr->spi_lock);
++		if (elbasr->spi)
++			elbasr->speed_hz = elbasr->spi->max_speed_hz;
++
++		/* ... after we unbound from the underlying device? */
++		dofree = (elbasr->spi == NULL);
++		spin_unlock_irq(&elbasr->spi_lock);
++
++		if (dofree)
++			kfree(elbasr);
++	}
++	mutex_unlock(&device_list_lock);
++
++	return 0;
++}
++
++static const struct file_operations elbasr_spi_fops = {
++	.owner =	THIS_MODULE,
++	/* REVISIT switch to aio primitives, so that userspace
++	 * gets more complete API coverage.  It'll simplify things
++	 * too, except for the locking.
++	 */
++	.write =	elbasr_spi_write,
++	.read =		elbasr_spi_read,
++	.unlocked_ioctl = elbasr_spi_ioctl,
++	.compat_ioctl = elbasr_spi_compat_ioctl,
++	.open =		elbasr_spi_open,
++	.release =	elbasr_spi_release,
++	.llseek =	no_llseek,
++};
++
++/* The main reason to have this class is to make mdev/udev create the
++ * /dev/spidevB.C character device nodes exposing our userspace API.
++ * It also simplifies memory management.
++ */
++
++static struct class *elbasr_spi_class;
++
++#ifdef CONFIG_OF
++static const struct of_device_id elbasr_spi_dt_ids[] = {
++	{ .compatible = "pensando,elbasr" },
++	{ /* sentinel */ },
++};
++MODULE_DEVICE_TABLE(of, elbasr_spi_dt_ids);
++#endif
++
++static int
++elbasr_regs_read(void *ctx, u32 reg, u32 *val)
++{
++	struct elbasr_data *elbasr = dev_get_drvdata(ctx);
++	struct spi_message m;
++	struct spi_transfer t[2] = { { 0 } };
++	int ret;
++	u8 txbuf[3];
++	u8 rxbuf[1];
++
++	spi_message_init(&m);
++
++	txbuf[0] = ELBASR_SPI_CMD_REGRD;
++	txbuf[1] = reg;
++	txbuf[2] = 0x0;
++	t[0].tx_buf = (u8 *)txbuf;
++	t[0].len = 3;
++
++	rxbuf[0] = 0x0;
++	t[1].rx_buf = rxbuf;
++	t[1].len = 1;
++
++	spi_message_add_tail(&t[0], &m);
++	spi_message_add_tail(&t[1], &m);
++
++	ret = elbasr_spi_sync(elbasr, &m);
++	if (ret == 4) {
++		// 3 Tx + 1 Rx = 4
++		*val = rxbuf[0];
++		return 0;
++	}
++	return -EIO;
++}
++
++static int
++elbasr_regs_write(void *ctx, u32 reg, u32 val)
++{
++	struct elbasr_data *elbasr = dev_get_drvdata(ctx);
++	struct spi_message m;
++	struct spi_transfer t[1] = { { 0 } };
++	u8 txbuf[4];
++
++	spi_message_init(&m);
++	txbuf[0] = ELBASR_SPI_CMD_REGWR;
++	txbuf[1] = reg;
++	txbuf[2] = val;
++	txbuf[3] = 0;
++
++	t[0].tx_buf = txbuf;
++	t[0].len = 4;
++
++	spi_message_add_tail(&t[0], &m);
++
++	return elbasr_spi_sync(elbasr, &m);
++}
++
++static const struct regmap_config pensando_elbasr_regmap_config = {
++	.reg_bits = 8,
++	.val_bits = 8,
++	.cache_type = REGCACHE_NONE,
++	.reg_read = elbasr_regs_read,
++	.reg_write = elbasr_regs_write,
++	.max_register = ELBASR_MAX_REG
++};
++
++/*
++ * Setup Elba SPI access to System Resource Chip registers on CS0
++ */
++static int
++elbasr_regs_setup(struct spi_device *spi, struct elbasr_data *elbasr)
++{
++	int ret;
++
++	spi->bits_per_word = 8;
++	spi_setup(spi);
++	elbasr->elbasr_regs = devm_regmap_init(&spi->dev, NULL, spi,
++					       &pensando_elbasr_regmap_config);
++	if (IS_ERR(elbasr->elbasr_regs)) {
++		ret = PTR_ERR(elbasr->elbasr_regs);
++		dev_err(&spi->dev, "Failed to allocate register map: %d\n", ret);
++		return ret;
++	}
++
++	ret = devm_mfd_add_devices(&spi->dev, PLATFORM_DEVID_NONE,
++				   pensando_elbasr_subdev_info,
++				   ARRAY_SIZE(pensando_elbasr_subdev_info),
++				   NULL, 0, NULL);
++	if (ret)
++		dev_err(&spi->dev, "Failed to register sub-devices: %d\n", ret);
++
++	return ret;
++}
++
++static int elbasr_spi_probe(struct spi_device *spi)
++{
++	struct elbasr_data *elbasr;
++	unsigned long minor;
++	int status;
++
++	/* Allocate driver data */
++	elbasr = kzalloc(sizeof(*elbasr), GFP_KERNEL);
++	if (!elbasr)
++		return -ENOMEM;
++
++	/* Initialize the driver data */
++	elbasr->spi = spi;
++	spin_lock_init(&elbasr->spi_lock);
++	mutex_init(&elbasr->buf_lock);
++
++	INIT_LIST_HEAD(&elbasr->device_entry);
++
++	/* If we can allocate a minor number, hook up this device.
++	 * Reusing minors is fine so long as udev or mdev is working.
++	 */
++	mutex_lock(&device_list_lock);
++	minor = find_first_zero_bit(minors, N_SPI_MINORS);
++	if (minor < N_SPI_MINORS) {
++		struct device *dev;
++
++		elbasr->devt = MKDEV(SPIDEV_MAJOR, minor);
++		dev = device_create(elbasr_spi_class, &spi->dev, elbasr->devt,
++				    elbasr, "spidev%d.%d",
++				    spi->master->bus_num, spi->chip_select);
++
++		status = PTR_ERR_OR_ZERO(dev);
++	} else {
++		dev_dbg(&spi->dev, "no minor number available!\n");
++		status = -ENODEV;
++	}
++	if (status == 0) {
++		set_bit(minor, minors);
++		list_add(&elbasr->device_entry, &device_list);
++	}
++	mutex_unlock(&device_list_lock);
++
++	elbasr->speed_hz = spi->max_speed_hz;
++
++	if (status == 0) {
++		spi_set_drvdata(spi, elbasr);
++		if (spi->chip_select == 0)
++			elbasr_regs_setup(spi, elbasr);
++	} else {
++		kfree(elbasr);
++	}
++
++	return status;
++}
++
++static int elbasr_spi_remove(struct spi_device *spi)
++{
++	struct elbasr_data *elbasr = spi_get_drvdata(spi);
++
++	/* prevent new opens */
++	mutex_lock(&device_list_lock);
++	/* make sure ops on existing fds can abort cleanly */
++	spin_lock_irq(&elbasr->spi_lock);
++	elbasr->spi = NULL;
++	spin_unlock_irq(&elbasr->spi_lock);
++
++	list_del(&elbasr->device_entry);
++	device_destroy(elbasr_spi_class, elbasr->devt);
++	clear_bit(MINOR(elbasr->devt), minors);
++	if (elbasr->users == 0)
++		kfree(elbasr);
++	mutex_unlock(&device_list_lock);
++
++	return 0;
++}
++
++static struct spi_driver elbasr_spi_driver = {
++	.driver = {
++		.name = "elbasr_spi",
++		.of_match_table = of_match_ptr(elbasr_spi_dt_ids),
++	},
++	.probe = elbasr_spi_probe,
++	.remove = elbasr_spi_remove,
++
++	/* NOTE:  suspend/resume methods are not necessary here.
++	 * We don't do anything except pass the requests to/from
++	 * the underlying controller.  The refrigerator handles
++	 * most issues; the controller driver handles the rest.
++	 */
++};
++
++static int __init elbasr_spi_init(void)
++{
++	int status;
++
++	/* Claim our 256 reserved device numbers.  Then register a class
++	 * that will key udev/mdev to add/remove /dev nodes.  Last, register
++	 * the driver which manages those device numbers.
++	 */
++	BUILD_BUG_ON(N_SPI_MINORS > 256);
++	status = register_chrdev(SPIDEV_MAJOR, "spi", &elbasr_spi_fops);
++	if (status < 0)
++		return status;
++
++	/* Backward compatibility for now */
++	elbasr_spi_class = class_create(THIS_MODULE, "elbasr_spi");
++	if (IS_ERR(elbasr_spi_class)) {
++		unregister_chrdev(SPIDEV_MAJOR, elbasr_spi_driver.driver.name);
++		return PTR_ERR(elbasr_spi_class);
++	}
++
++	status = spi_register_driver(&elbasr_spi_driver);
++	if (status < 0) {
++		class_destroy(elbasr_spi_class);
++		unregister_chrdev(SPIDEV_MAJOR, elbasr_spi_driver.driver.name);
++	}
++	return status;
++}
++module_init(elbasr_spi_init);
++
++static void __exit elbasr_spi_exit(void)
++{
++	spi_unregister_driver(&elbasr_spi_driver);
++	class_destroy(elbasr_spi_class);
++	unregister_chrdev(SPIDEV_MAJOR, elbasr_spi_driver.driver.name);
++}
++module_exit(elbasr_spi_exit);
++
++MODULE_AUTHOR("Brad Larson, <brad@pensando.io>");
++MODULE_DESCRIPTION("Pensando Elba System Resource device interface");
++MODULE_LICENSE("GPL");
++MODULE_ALIAS("spi:elbasr_spi");
+diff --git a/drivers/mmc/host/sdhci-cadence.c b/drivers/mmc/host/sdhci-cadence.c
+index f755083ac9e1..30c44b4f2704 100644
+--- a/drivers/mmc/host/sdhci-cadence.c
++++ b/drivers/mmc/host/sdhci-cadence.c
+@@ -21,6 +21,7 @@
+ #include <linux/mmc/mmc.h>
+ #include <linux/of.h>
+ #include <linux/of_device.h>
++#include <linux/reset.h>
+ 
+ #include "sdhci-pltfm.h"
+ #include "sdhci-cadence.h"
+@@ -338,6 +339,22 @@ static void sdhci_cdns_hs400_enhanced_strobe(struct mmc_host *mmc,
+ 					 SDHCI_CDNS_HRS06_MODE_MMC_HS400);
+ }
+ 
++static void sdhci_mmc_hw_reset(struct mmc_host *mmc)
++{
++	struct sdhci_host *host = mmc_priv(mmc);
++	struct sdhci_cdns_priv *priv = sdhci_cdns_priv(host);
++
++	dev_info(mmc_dev(host->mmc), "emmc hardware reset\n");
++
++	reset_control_assert(priv->rst_hw);
++	/* For eMMC, minimum is 1us but give it 9us for good measure */
++	udelay(9);
++
++	reset_control_deassert(priv->rst_hw);
++	/* For eMMC, minimum is 200us but give it 300us for good measure */
++	usleep_range(300, 1000);
++}
++
+ static int sdhci_cdns_probe(struct platform_device *pdev)
+ {
+ 	const struct sdhci_cdns_drv_data *data;
+@@ -400,6 +417,17 @@ static int sdhci_cdns_probe(struct platform_device *pdev)
+ 	if (ret)
+ 		goto free;
+ 
++	if (host->mmc->caps & MMC_CAP_HW_RESET) {
++		priv->rst_hw = devm_reset_control_get_optional_exclusive(dev, "hw");
++		if (IS_ERR(priv->rst_hw)) {
++			ret = PTR_ERR(priv->rst_hw);
++			if (ret == -ENOENT)
++				priv->rst_hw = NULL;
++		} else {
++			host->mmc_host_ops.hw_reset = sdhci_mmc_hw_reset;
++		}
++	}
++
+ 	ret = sdhci_add_host(host);
+ 	if (ret)
+ 		goto free;
+diff --git a/drivers/mmc/host/sdhci-cadence.h b/drivers/mmc/host/sdhci-cadence.h
+index 4c6429b11f0b..ef46db6eacb6 100644
+--- a/drivers/mmc/host/sdhci-cadence.h
++++ b/drivers/mmc/host/sdhci-cadence.h
+@@ -30,6 +30,7 @@ struct sdhci_cdns_priv {
+ 	bool enhanced_strobe;
+ 	void (*priv_write_l)(struct sdhci_cdns_priv *priv,
+                 u32 val, void __iomem *reg); /* for cadence-elba.c */
++	struct reset_control *rst_hw;
+ 	unsigned int nr_phy_params;
+ 	struct sdhci_cdns_phy_param phy_params[0];
+ };
+diff --git a/drivers/reset/Kconfig b/drivers/reset/Kconfig
+index e2baecbb9dd3..8f448acd1a34 100644
+--- a/drivers/reset/Kconfig
++++ b/drivers/reset/Kconfig
+@@ -34,6 +34,14 @@ config RESET_BERLIN
+ 	help
+ 	  This enables the reset controller driver for Marvell Berlin SoCs.
+ 
++config RESET_ELBASR
++	tristate "Pensando Elba System Resource Reset"
++	depends on MFD_PENSANDO_ELBASR
++	help
++	  This option enables support for the external reset functions
++	  on the Pensando Elba System Resource Chip.  Supported functions
++	  include eMMC hardware reset.
++
+ config RESET_HSDK
+ 	bool "Synopsys HSDK Reset Driver"
+ 	depends on HAS_IOMEM
+diff --git a/drivers/reset/Makefile b/drivers/reset/Makefile
+index c1fd702ac57c..4e56adcd861b 100644
+--- a/drivers/reset/Makefile
++++ b/drivers/reset/Makefile
+@@ -6,6 +6,7 @@ obj-$(CONFIG_ARCH_TEGRA) += tegra/
+ obj-$(CONFIG_RESET_A10SR) += reset-a10sr.o
+ obj-$(CONFIG_RESET_ATH79) += reset-ath79.o
+ obj-$(CONFIG_RESET_BERLIN) += reset-berlin.o
++obj-$(CONFIG_RESET_ELBASR) += reset-elbasr.o
+ obj-$(CONFIG_RESET_HSDK) += reset-hsdk.o
+ obj-$(CONFIG_RESET_IMX7) += reset-imx7.o
+ obj-$(CONFIG_RESET_LANTIQ) += reset-lantiq.o
+diff --git a/drivers/reset/reset-elbasr.c b/drivers/reset/reset-elbasr.c
+new file mode 100644
+index 000000000000..65af5968ddb3
+--- /dev/null
++++ b/drivers/reset/reset-elbasr.c
+@@ -0,0 +1,84 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2022 Pensando Systems Inc.
++ */
++
++#include <linux/mfd/pensando-elbasr.h>
++#include <linux/platform_device.h>
++#include <linux/reset-controller.h>
++#include <linux/regmap.h>
++#include <linux/err.h>
++#include <linux/of.h>
++
++struct elbasr_reset {
++	struct reset_controller_dev rcdev;
++	struct regmap *regmap;
++};
++
++static inline struct elbasr_reset *to_elbasr_rst(struct reset_controller_dev *rc)
++{
++	return container_of(rc, struct elbasr_reset, rcdev);
++}
++
++static int elbasr_reset_assert(struct reset_controller_dev *rcdev,
++			       unsigned long id)
++{
++	struct elbasr_reset *elbar = to_elbasr_rst(rcdev);
++	u32 mask = EMMC_HW_RESET;
++
++	return regmap_update_bits(elbar->regmap, ELBASR_ASIC_CONTROL_REG0,
++				  mask, mask);
++}
++
++static int elbasr_reset_deassert(struct reset_controller_dev *rcdev,
++				 unsigned long id)
++{
++	struct elbasr_reset *elbar = to_elbasr_rst(rcdev);
++	u32 mask = EMMC_HW_RESET;
++
++	return regmap_update_bits(elbar->regmap, ELBASR_ASIC_CONTROL_REG0,
++				  mask, 0);
++}
++
++static const struct reset_control_ops elbasr_reset_ops = {
++	.assert	= elbasr_reset_assert,
++	.deassert = elbasr_reset_deassert,
++};
++
++static int elbasr_reset_probe(struct platform_device *pdev)
++{
++	struct elbasr_data *elbasr = dev_get_drvdata(pdev->dev.parent);
++	struct elbasr_reset *elbar;
++	int ret;
++
++	elbar = devm_kzalloc(&pdev->dev, sizeof(struct elbasr_reset),
++			     GFP_KERNEL);
++	if (!elbar)
++		return -ENOMEM;
++
++	elbar->rcdev.owner = THIS_MODULE;
++	elbar->rcdev.nr_resets = ELBASR_NR_RESETS;
++	elbar->rcdev.ops = &elbasr_reset_ops;
++	elbar->rcdev.of_node = pdev->dev.of_node;
++	elbar->regmap = elbasr->elbasr_regs;
++
++	platform_set_drvdata(pdev, elbar);
++
++	ret = devm_reset_controller_register(&pdev->dev, &elbar->rcdev);
++
++	return ret;
++}
++
++static const struct of_device_id elba_reset_dt_match[] = {
++	{ .compatible = "pensando,elbasr-reset", },
++	{ /* sentinel */ },
++};
++
++static struct platform_driver elbasr_reset_driver = {
++	.probe	= elbasr_reset_probe,
++	.driver = {
++		.name = "pensando_elbasr_reset",
++		.of_match_table	= elba_reset_dt_match,
++	},
++};
++builtin_platform_driver(elbasr_reset_driver);
+diff --git a/drivers/spi/spidev.c b/drivers/spi/spidev.c
+index 64f7038aa1fa..cda10719d1d1 100644
+--- a/drivers/spi/spidev.c
++++ b/drivers/spi/spidev.c
+@@ -669,7 +669,6 @@ static const struct of_device_id spidev_dt_ids[] = {
+ 	{ .compatible = "lineartechnology,ltc2488" },
+ 	{ .compatible = "ge,achc" },
+ 	{ .compatible = "semtech,sx1301" },
+-	{ .compatible = "pensando,cpld" },
+ 	{},
+ };
+ MODULE_DEVICE_TABLE(of, spidev_dt_ids);
+diff --git a/include/linux/mfd/pensando-elbasr.h b/include/linux/mfd/pensando-elbasr.h
+new file mode 100644
+index 000000000000..7082d5d9d244
+--- /dev/null
++++ b/include/linux/mfd/pensando-elbasr.h
+@@ -0,0 +1,43 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later */
++/*
++ * Copyright (C) 2022 Pensando Systems, Inc.
++ *
++ * Declarations for Pensando Elba System Resource Chip
++ *
++ */
++
++#ifndef __MFD_PENSANDO_ELBA_H
++#define __MFD_PENSANDO_ELBA_H
++
++#include <linux/mfd/core.h>
++#include <linux/regmap.h>
++#include <linux/spinlock.h>
++#include <linux/uaccess.h>
++
++#define ELBASR_MAX_REG			0x80
++#define ELBASR_NR_RESETS		1
++
++#define ELBASR_ASIC_CONTROL_REG0	0x10
++#define EMMC_HW_RESET			BIT(6)
++
++/*
++ * Pensando Elba System Resource MFD device private data structure
++ */
++struct elbasr_data {
++	dev_t devt;
++	spinlock_t spi_lock;
++	struct spi_device *spi;
++	struct list_head device_entry;
++
++	/* TX/RX buffers are NULL unless this device is open (users > 0) */
++	struct mutex buf_lock;
++	unsigned int users;
++	u8 *tx_buffer;
++	u8 *rx_buffer;
++	u32 speed_hz;
++
++	/* System Resource Chip CS0 register access */
++	struct regmap *elbasr_regs;
++};
++
++#endif /* __MFD_PENSANDO_ELBA_H */
+-- 
+2.17.1
+

--- a/dsc-linux-4.14.18/patches-2022-05/README.md
+++ b/dsc-linux-4.14.18/patches-2022-05/README.md
@@ -1,0 +1,7 @@
+This directory is a continuation of patches from patches-2022-01; applying
+to a v4.14.18 kernel tree, to support the Pensando Elba ASIC.
+
+**0000_emmc_hwreset.patch**<br>
+Add support for Pensando Elba System Resource Chip for userspace access
+to the device and hardware reset of the eMMC.  The System Resource Chip
+is accessed over a SPI bus using regmap framework.


### PR DESCRIPTION
Enable eMMC hardware reset.  Process followed:

```
1. In branch platform-linux/oracle-4.14.18 back ported what was committed
   to 1.15.9-C to enable eMMC hardware reset.

2. Commit to work branch to generate a signed off patch (below).  We
   provide a series of directories which contain a README and one or
   more patches.

Author: Brad Larson <brad@pensando.io>
Date:   Tue May 17 13:37:25 2022 -0700

    mfd: pensando_elbasr: Add Pensando Elba System Resource Chip

    Add support for Pensando Elba System Resource Chip
    for userspace access to the device and hardware
    reset of the eMMC.  The System Resource Chip is
    accessed over a SPI bus using regmap framework.

    Signed-off-by: Brad Larson <brad@pensando.io>

3. Created directory dsc-linux-patches/dsc-linux-4.14.18/patches-2022-05
   and add patch 00_emmc_hwreset.patch and README.md

4. Pulled platform-linux/oracle-4.14.18 again to check that the patch
   applies cleanly, builds and runs.  On platform-dev1:

$ patch -p1 < /local3/brad/ws1/src/github.com/pensando/dsc-linux-patches/dsc-linux-4.14.18/patches-2022-05/00_emmc_hwreset.patch
patching file arch/arm64/boot/dts/pensando/elba-asic-common.dtsi
patching file arch/arm64/configs/elba_defconfig
patching file drivers/mfd/Kconfig
patching file drivers/mfd/Makefile
patching file drivers/mfd/pensando-elbasr.c
patching file drivers/mmc/host/sdhci-cadence.c
patching file drivers/mmc/host/sdhci-cadence.h
patching file drivers/reset/Kconfig
patching file drivers/reset/Makefile
patching file drivers/reset/reset-elbasr.c
patching file drivers/spi/spidev.c
patching file include/linux/mfd/pensando-elbasr.h

$ make ARCH=arm64 elba_defconfig
...
$ ARCH=arm64 ./m-elba
...
$ cp kernel.img ~/kernel.img

On Ortano running mainfwb, just change out the kernel

# scp brad@192.168.65.151:~/kernel.img /data/.
...
# /data/install_file mainfwa /data/kernel.img && fwupdate -s mainfwa
...
===> New startup version 1.15.9-C-64-1-3-dirty vs. running 1.15.9-C-64-1-3-dirty
OK

After reboot

# cpldapp -r 0
0x3
# cpldapp -r 0x80
0x43

# dmesg|more
[    0.000000] Booting Linux on physical CPU 0x0
[    0.000000] Linux version 4.14.18 (brad@platform-dev1) (gcc version 6.4.1 201
70707 (Linaro GCC 6.4-2017.08)) #1 SMP Tue May 17 14:05:37 PDT 2022

# uname -a
Linux elba 4.14.18 #1 SMP Tue May 17 14:05:37 PDT 2022 aarch64 GNU/Linux

# dmesg|grep mmc
[    0.174190] mmc0: SDHCI controller on 30440000.sdio-host-chip [30440000.sdio-host-chip] using ADMA
[    0.174197] sdhci-cdns 30440000.sdio-host-chip: emmc hardware reset    <========
[    0.264035] mmc0: new HS200 MMC card at address 0001
[    0.264147] mmcblk0: mmc0:0001 S0J58X 29.6 GiB
[    0.264198] mmcblk0boot0: mmc0:0001 S0J58X partition 1 31.5 MiB
[    0.264244] mmcblk0boot1: mmc0:0001 S0J58X partition 2 31.5 MiB
[    0.264292] mmcblk0rpmb: mmc0:0001 S0J58X partition 3 4.00 MiB
[    0.266933]  mmcblk0: p1 p2 p3 p4 p5 p6 p7 p8 p9 p10

# find .|grep reset
./soc/sdio-host-chip@30440000/cap-mmc-hw-reset
./soc/sdio-host-chip@30440000/resets
./soc/sdio-host-chip@30440000/reset-names
./soc/ssi@2800/spi@0/reset-controller@0
./soc/ssi@2800/spi@0/reset-controller@0/compatible
./soc/ssi@2800/spi@0/reset-controller@0/#reset-cells
./soc/ssi@2800/spi@0/reset-controller@0/#address-cells
./soc/ssi@2800/spi@0/reset-controller@0/#size-cells
./soc/ssi@2800/spi@0/reset-controller@0/phandle
./soc/ssi@2800/spi@0/reset-controller@0/reg
./soc/ssi@2800/spi@0/reset-controller@0/linux,phandle
./soc/ssi@2800/spi@0/reset-controller@0/name
```