### PR TITLE
Salina Linux 5.15.129 patch release 04/11/25

### DIFF
--- a/dsc-linux-5.15.129/patches-2025-04/0009-arm-gic-its-msi-encapsulator-address-configured-from.patch
+++ b/dsc-linux-5.15.129/patches-2025-04/0009-arm-gic-its-msi-encapsulator-address-configured-from.patch
@@ -1,0 +1,67 @@
+From 049e4f0d4a4884a55212ec2f854a3490ee27e2da Mon Sep 17 00:00:00 2001
+From: Brad Larson <bradley.larson@amd.com>
+Date: Thu, 10 Apr 2025 19:50:19 -0700
+Subject: [PATCH] arm gic its msi encapsulator address configured from device
+ tree
+
+The salina gic its interrupt translator is configured at a
+custom offset.  This change adds support to the standard arm gic its
+driver to specify the custom offset in the git its node of the
+device tree to handle this salina quirk.
+
+Signed-off-by: Brad Larson <bradley.larson@amd.com>
+---
+ drivers/irqchip/irq-gic-v3-its.c | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/drivers/irqchip/irq-gic-v3-its.c b/drivers/irqchip/irq-gic-v3-its.c
+index 490e6cfe510e..ae56a5fc078d 100644
+--- a/drivers/irqchip/irq-gic-v3-its.c
++++ b/drivers/irqchip/irq-gic-v3-its.c
+@@ -115,6 +115,7 @@ struct its_node {
+ 	unsigned int		msi_domain_flags;
+ 	u32			pre_its_base; /* for Socionext Synquacer */
+ 	int			vlpi_redist_offset;
++	u64			msi_encapsulator;
+ };
+ 
+ #define is_v4(its)		(!!((its)->typer & GITS_TYPER_VLPIS))
+@@ -1705,6 +1706,8 @@ static u64 its_irq_get_msi_base(struct its_device *its_dev)
+ {
+ 	struct its_node *its = its_dev->its;
+ 
++	if (its->msi_encapsulator)
++		return its->msi_encapsulator;
+ 	return its->phys_base + GITS_TRANSLATER;
+ }
+ 
+@@ -5239,6 +5242,8 @@ static int __init its_of_probe(struct device_node *node)
+ 
+ 	for (np = of_find_matching_node(node, its_device_id); np;
+ 	     np = of_find_matching_node(np, its_device_id)) {
++		struct its_node *its = NULL;
++
+ 		if (!of_device_is_available(np))
+ 			continue;
+ 		if (!of_property_read_bool(np, "msi-controller")) {
+@@ -5253,6 +5258,17 @@ static int __init its_of_probe(struct device_node *node)
+ 		}
+ 
+ 		its_probe_one(&res, &np->fwnode, of_node_to_nid(np));
++
++		/* Find the last-added its_node */
++		raw_spin_lock(&its_lock);
++		if (!list_empty(&its_nodes))
++			its = list_last_entry(&its_nodes, struct its_node, entry);
++		raw_spin_unlock(&its_lock);
++
++		if (its && of_address_to_resource(np, 1, &res) == 0) {
++			its->msi_encapsulator = res.start;
++			pr_info("its msi encapsulator 0x%llx\n", its->msi_encapsulator);
++                }
+ 	}
+ 	return 0;
+ }
+-- 
+2.25.1
+


### PR DESCRIPTION
This Salina ITS quirk was missed in the port to dsc-linux 5.15.129.  This log message is now seen booting 5.15 on Leni N1 and ionic interrupts are working.
```
[    0.000000] its msi encapsulator 0x1400040
```