### PR TITLE
Linux 5.15.129 patch release 03/23/2026

### DIFF
--- a/dsc-linux-5.15.129/patches-2026-03/00-i2c-designware-timeout-fix.patch
+++ b/dsc-linux-5.15.129/patches-2026-03/00-i2c-designware-timeout-fix.patch
@@ -1,0 +1,90 @@
+From ad847bf9546d2b4a3d541f10ee969f6424a4bb39 Mon Sep 17 00:00:00 2001
+From: Brad Larson <bradley.larson@amd.com>
+Date: Thu, 26 Feb 2026 12:35:16 -0800
+Subject: [PATCH] i2c: designware: fix __i2c_dw_disable() in case master is
+ holding SCL low
+
+The DesignWare IP can be synthesized with the IC_EMPTYFIFO_HOLD_MASTER_EN
+parameter.
+In this case, when the TX FIFO gets empty and the last command didn't have
+the STOP bit (IC_DATA_CMD[9]), the controller will hold SCL low until
+a new command is pushed into the TX FIFO or the transfer is aborted.
+
+When the controller is holding SCL low, it cannot be disabled.
+The transfer must first be aborted.
+Also, the bus recovery won't work because SCL is held low by the master.
+
+Check if the master is holding SCL low in __i2c_dw_disable() before trying
+to disable the controller. If SCL is held low, an abort is initiated.
+When the abort is done, then proceed with disabling the controller.
+
+This whole situation can happen for instance during SMBus read data block
+if the slave just responds with "byte count == 0".
+This puts the driver in an unrecoverable state, because the controller is
+holding SCL low and the current __i2c_dw_disable() procedure is not
+working. In this situation only a SoC reset can fix the i2c bus.
+
+Co-developed-by: Jonathan Borne <jborne@kalray.eu>
+Signed-off-by: Jonathan Borne <jborne@kalray.eu>
+Signed-off-by: Yann Sionneau <ysionneau@kalray.eu>
+Acked-by: Jarkko Nikula <jarkko.nikula@linux.intel.com>
+Signed-off-by: Wolfram Sang <wsa@kernel.org>
+---
+ drivers/i2c/busses/i2c-designware-common.c | 17 +++++++++++++++++
+ drivers/i2c/busses/i2c-designware-core.h   |  3 +++
+ 2 files changed, 20 insertions(+)
+
+diff --git a/drivers/i2c/busses/i2c-designware-common.c b/drivers/i2c/busses/i2c-designware-common.c
+index a6bdff65b385..4aff32b0b26b 100644
+--- a/drivers/i2c/busses/i2c-designware-common.c
++++ b/drivers/i2c/busses/i2c-designware-common.c
+@@ -443,8 +443,25 @@ int i2c_dw_set_sda_hold(struct dw_i2c_dev *dev)
+ 
+ void __i2c_dw_disable(struct dw_i2c_dev *dev)
+ {
++	unsigned int raw_intr_stats;
++	unsigned int enable;
+ 	int timeout = 100;
+ 	u32 status;
++	bool abort_needed;
++	int ret;
++
++	regmap_read(dev->map, DW_IC_RAW_INTR_STAT, &raw_intr_stats);
++	regmap_read(dev->map, DW_IC_ENABLE, &enable);
++
++	abort_needed = raw_intr_stats & DW_IC_INTR_MST_ON_HOLD;
++	if (abort_needed) {
++		regmap_write(dev->map, DW_IC_ENABLE, enable | DW_IC_ENABLE_ABORT);
++		ret = regmap_read_poll_timeout(dev->map, DW_IC_ENABLE, enable,
++					       !(enable & DW_IC_ENABLE_ABORT), 10,
++					       100);
++		if (ret)
++			dev_err(dev->dev, "timeout while trying to abort current transfer\n");
++	}
+ 
+ 	do {
+ 		__i2c_dw_disable_nowait(dev);
+diff --git a/drivers/i2c/busses/i2c-designware-core.h b/drivers/i2c/busses/i2c-designware-core.h
+index acbc60a5627f..ad9e5994d68e 100644
+--- a/drivers/i2c/busses/i2c-designware-core.h
++++ b/drivers/i2c/busses/i2c-designware-core.h
+@@ -99,6 +99,7 @@
+ #define DW_IC_INTR_START_DET	BIT(10)
+ #define DW_IC_INTR_GEN_CALL	BIT(11)
+ #define DW_IC_INTR_RESTART_DET	BIT(12)
++#define DW_IC_INTR_MST_ON_HOLD	BIT(13)
+ #define DW_IC_INTR_SCL_STUCK_AT_LOW	BIT(14)
+ 
+ #define DW_IC_INTR_DEFAULT_MASK		(DW_IC_INTR_RX_FULL | \
+@@ -113,6 +114,8 @@
+ 
+ #define DW_IC_SDA_STUCK_RECOVERY_ENABLE	BIT(3)
+ 
++#define DW_IC_ENABLE_ABORT             BIT(1)
++
+ #define DW_IC_STATUS_ACTIVITY		BIT(0)
+ #define DW_IC_STATUS_TFE		BIT(2)
+ #define DW_IC_STATUS_MASTER_ACTIVITY	BIT(5)
+-- 
+2.25.1
+

--- a/dsc-linux-5.15.129/patches-2026-03/01-mmc-hpi-to-interrupt-lengthy-cache-flush.patch
+++ b/dsc-linux-5.15.129/patches-2026-03/01-mmc-hpi-to-interrupt-lengthy-cache-flush.patch
@@ -1,0 +1,96 @@
+From e7247c30a88d666e908d4d1110bab8f810502b4d Mon Sep 17 00:00:00 2001
+From: Brad Larson <bradley.larson@amd.com>
+Date: Mon, 23 Mar 2026 12:44:01 -0700
+Subject: [PATCH] mmc: core: Use HPI to interrupt lengthy cache flush (#494)
+
+There is no cache flush duration time limit per JEDEC
+and the default timeout is 30 seconds with no retry.
+When this timeout occurs a filesystem partition may
+go read only.
+
+JEDEC compliant devices support HPI to interrupt the
+cache flush.  Support HPI interrupt of lengthy cache
+flush to allow normal IO and then when the next periodic
+cache flush is issued the cache flush continues.
+
+Signed-off-by: Brad Larson <bradley.larson@amd.com>
+---
+ drivers/mmc/core/mmc_ops.c | 27 +++++++++++++++++++++++++--
+ 1 file changed, 25 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/mmc/core/mmc_ops.c b/drivers/mmc/core/mmc_ops.c
+index 0c54858e89c0..87467ab8ea12 100644
+--- a/drivers/mmc/core/mmc_ops.c
++++ b/drivers/mmc/core/mmc_ops.c
+@@ -20,6 +20,7 @@
+ #include "mmc_ops.h"
+ 
+ #define MMC_BKOPS_TIMEOUT_MS		(120 * 1000) /* 120s */
++#define MMC_CACHE_FLUSH_INTERRUPT_MS	(3 * 1000) /* 3s */
+ #define MMC_SANITIZE_TIMEOUT_MS		(240 * 1000) /* 240s */
+ 
+ static const u8 tuning_blk_pattern_4bit[] = {
+@@ -56,8 +57,12 @@ struct mmc_busy_data {
+ 	struct mmc_card *card;
+ 	bool retry_crc_err;
+ 	enum mmc_busy_cmd busy_cmd;
++	unsigned long timeout_hpi;
++	bool hpi_sent;
+ };
+ 
++static int mmc_send_hpi_cmd(struct mmc_card *card);
++
+ int __mmc_send_status(struct mmc_card *card, u32 *status, unsigned int retries)
+ {
+ 	int err;
+@@ -437,13 +442,13 @@ static int mmc_busy_cb(void *cb_data, bool *busy)
+ 
+ 	if (data->busy_cmd != MMC_BUSY_IO && host->ops->card_busy) {
+ 		*busy = host->ops->card_busy(host);
+-		return 0;
++		goto maybe_hpi;
+ 	}
+ 
+ 	err = mmc_send_status(data->card, &status);
+ 	if (data->retry_crc_err && err == -EILSEQ) {
+ 		*busy = true;
+-		return 0;
++		goto maybe_hpi;
+ 	}
+ 	if (err)
+ 		return err;
+@@ -467,6 +472,21 @@ static int mmc_busy_cb(void *cb_data, bool *busy)
+ 		return err;
+ 
+ 	*busy = !mmc_ready_for_data(status);
++
++maybe_hpi:
++	if (!data->hpi_sent && data->card->ext_csd.hpi_en &&
++	    time_after(jiffies, data->timeout_hpi) && *busy &&
++	    data->busy_cmd == MMC_BUSY_CMD6) {
++		err = mmc_send_hpi_cmd(data->card);
++		if (err) {
++			pr_err("%s: HPI to interrupt cache flush failed %d\n",
++			       mmc_hostname(host), err);
++		} else {
++			pr_info("%s: HPI sent to interrupt cache flush\n",
++				mmc_hostname(host));
++			data->hpi_sent = true;
++		}
++	}
+ 	return 0;
+ }
+ 
+@@ -520,6 +540,9 @@ int mmc_poll_for_busy(struct mmc_card *card, unsigned int timeout_ms,
+ 	cb_data.card = card;
+ 	cb_data.retry_crc_err = retry_crc_err;
+ 	cb_data.busy_cmd = busy_cmd;
++	cb_data.timeout_hpi = jiffies +
++		msecs_to_jiffies(MMC_CACHE_FLUSH_INTERRUPT_MS) + 1;
++	cb_data.hpi_sent = false;
+ 
+ 	return __mmc_poll_for_busy(card, timeout_ms, &mmc_busy_cb, &cb_data);
+ }
+-- 
+2.25.1
+

--- a/dsc-linux-5.15.129/patches-2026-03/README.md
+++ b/dsc-linux-5.15.129/patches-2026-03/README.md
@@ -1,0 +1,41 @@
+This directory is a continuation of patches from patches-2026-01; applying
+to a v5.15.129 kernel tree, to support the Pensando Elba ASIC based card.
+
+## Commits
+**00-i2c-designware-timeout-fix.patch**<br>
+```
+i2c: designware: fix __i2c_dw_disable() in case master is holding SCL low
+
+The DesignWare IP can be synthesized with the IC_EMPTYFIFO_HOLD_MASTER_EN
+parameter.  In this case, when the TX FIFO gets empty and the last command
+didn't have the STOP bit (IC_DATA_CMD[9]), the controller will hold SCL low
+until a new command is pushed into the TX FIFO or the transfer is aborted.
+
+When the controller is holding SCL low, it cannot be disabled.
+The transfer must first be aborted.
+Also, the bus recovery won't work because SCL is held low by the master.
+
+Check if the master is holding SCL low in __i2c_dw_disable() before trying
+to disable the controller. If SCL is held low, an abort is initiated.
+When the abort is done, then proceed with disabling the controller.
+
+This whole situation can happen for instance during SMBus read data block
+if the slave just responds with "byte count == 0".
+This puts the driver in an unrecoverable state, because the controller is
+holding SCL low and the current __i2c_dw_disable() procedure is not
+working. In this situation only a SoC reset can fix the i2c bus.
+```
+**01-mmc-hpi-to-interrupt-lengthy-cache-flush.patch**<br>
+```
+mmc: core: Use HPI to interrupt lengthy cache flush (#494)
+
+There is no cache flush duration time limit per JEDEC
+and the default timeout is 30 seconds with no retry.
+When this timeout occurs a filesystem partition may
+go read only.
+
+JEDEC compliant devices support HPI to interrupt the
+cache flush.  Support HPI interrupt of lengthy cache
+flush to allow normal IO and then when the next periodic
+cache flush is issued the cache flush continues.
+```


### PR DESCRIPTION
Updates include

- designware i2c timeout fix from upstream with minor changes
- rework emmc high priority interrupt for 5.15